### PR TITLE
Add providers for Germany (nationwide) and each German state

### DIFF
--- a/src/Michalmanko/Holiday/HolidayFactory.php
+++ b/src/Michalmanko/Holiday/HolidayFactory.php
@@ -31,6 +31,23 @@ abstract class HolidayFactory
     protected static $providers = array(
         'PL' => 'Poland',
         'DK' => 'Denmark',
+        'GER' => 'Germany',
+        'GER_BB' => 'GermanyBB',
+        'GER_BE' => 'GermanyBE',
+        'GER_BW' => 'GermanyBW',
+        'GER_BY' => 'GermanyBY',
+        'GER_HB' => 'GermanyHB',
+        'GER_HE' => 'GermanyHE',
+        'GER_HH' => 'GermanyHH',
+        'GER_MV' => 'GermanyMV',
+        'GER_NI' => 'GermanyNI',
+        'GER_NW' => 'GermanyNW',
+        'GER_RP' => 'GermanyRP',
+        'GER_SH' => 'GermanySH',
+        'GER_SL' => 'GermanySL',
+        'GER_SN' => 'GermanySN',
+        'GER_ST' => 'GermanyST',
+        'GER_TH' => 'GermanyTH',
     );
 
     /**

--- a/src/Michalmanko/Holiday/Provider/Germany.php
+++ b/src/Michalmanko/Holiday/Provider/Germany.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+use Michalmanko\Holiday\Holiday;
+
+/**
+ * German Holidays Provider (only contains nationwide holiday).
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class Germany extends AbstractProvider
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function prepareHolidays($year)
+    {
+        $data = new ArrayObject();
+
+        // New Year's Day
+        $data->append($this->createHoliday(
+            'Neujahr',
+            $year . '-01-01',
+            Holiday::TYPE_HOLIDAY
+        ));
+
+        // Epiphany (BW, BY, ST)
+
+        // Good Friday
+        $goodFriday = $this->createHoliday(
+            'Karfreitag',
+            $this->getEaster($year),
+            Holiday::TYPE_HOLIDAY
+        );
+        $goodFriday->modify('-2 days');
+        $data->append($goodFriday);
+
+        // Easter Sunday (BB, HE)
+
+        // Easter Monday
+        $easterMonday = $this->createHoliday(
+            'Ostermontag',
+            $this->getEaster($year),
+            Holiday::TYPE_HOLIDAY
+        );
+        $easterMonday->modify('+1 day');
+        $data->append($easterMonday);
+
+        // Feast of the Ascension
+        $feastOfTheAscension = $this->createHoliday(
+            'Christi Himmelfahrt',
+            $this->getEaster($year),
+            Holiday::TYPE_HOLIDAY
+        );
+        $feastOfTheAscension->modify('+39 day');
+        $data->append($feastOfTheAscension);
+
+        // Pentecost Sunday (BB, HE)
+
+        // Pentecost Monday
+        $pentecostMonday = $this->createHoliday(
+            'Pfingstmontag',
+            $this->getEaster($year),
+            Holiday::TYPE_HOLIDAY
+        );
+        $pentecostMonday->modify('+50 days');
+        $data->append($pentecostMonday);
+
+        // Corpus Christi (BW, BY, HE, NW, RP, SL)
+
+        // Assumption of the Blessed Virgin Mary (SL)
+
+        // Day of German Unity
+        $data->append($this->createHoliday(
+            'Tag der Deutschen Einheit',
+            $year . '-10-03',
+            Holiday::TYPE_HOLIDAY
+        ));
+
+        // Labour Day
+        $data->append($this->createHoliday(
+            'Erster Mai',
+            $year . '-05-01',
+            Holiday::TYPE_HOLIDAY
+        ));
+
+        // Reformation Day (BB, MV, SN, ST, SH, TH)
+        // only in the year 2017 is this a nationwide holiday
+        // source: https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland#cite_note-reform2-13
+        if ($year == 2017) {
+            $data->append($this->getHolidayReformationDay($year));
+        }
+
+        // All Saints' Day (BW, BY, NW, RP, SL)
+
+        // Buß- und Bettag (has no English translation, wednesday before the 23.11) (SN)
+
+        // Christmas Day
+        $data->append($this->createHoliday(
+            '1. Weihnachtstag',
+            $year . '-12-25',
+            Holiday::TYPE_HOLIDAY
+        ));
+        
+        // Boxing Day
+        $data->append($this->createHoliday(
+            '2. Weihnachtstag',
+            $year . '-12-26',
+            Holiday::TYPE_HOLIDAY
+        ));
+
+        return $data->getArrayCopy();
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayPentecostSunday($year)
+    {
+        $pentecost = $this->createHoliday('Pfingstsonntag', $this->getEaster($year), Holiday::TYPE_HOLIDAY);
+        $pentecost->modify('+49 days');
+        return $pentecost;
+
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayEpiphandy($year)
+    {
+        return $this->createHoliday('Heilige Drei Könige', $year . '-01-06', Holiday::TYPE_HOLIDAY);
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayEasterSunday($year)
+    {
+        return $this->createHoliday('Ostersonntag', $this->getEaster($year), Holiday::TYPE_HOLIDAY);
+    }
+
+    public function getHolidayCorpusChristi($year)
+    {
+        $corpusChristi = $this->createHoliday('Fronleichnam', $this->getEaster($year), Holiday::TYPE_HOLIDAY);
+        $corpusChristi->modify('+60 days');
+        return $corpusChristi;
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayAssumptionOfTheBlessedVirginMary($year)
+    {
+        return $this->createHoliday('Mariä Himmelfahrt', $year . '-08-15', Holiday::TYPE_HOLIDAY);
+    }
+
+    /**
+     * Be careful not to add this holiday to states in the year 2017 (nationwide holiday in 2017 only)
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayReformationDay($year)
+    {
+        return $this->createHoliday('Reformationstag', $year . '-10-31', Holiday::TYPE_HOLIDAY);
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayAllSaintsDay($year)
+    {
+        return $this->createHoliday('Allerheiligen', $year . '-11-01', Holiday::TYPE_HOLIDAY);
+    }
+
+    /**
+     * @param $year
+     * @return Holiday
+     */
+    public function getHolidayBuszUndBettTag($year)
+    {
+        // wednesday before 23-11-yyyy
+        $date = date('Y-m-d',strtotime('-1 Wednesday', strtotime($year . '-11-23')));
+        return $this->createHoliday('Buß- und Bettag', $date, Holiday::TYPE_HOLIDAY);
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/Germany.php
+++ b/src/Michalmanko/Holiday/Provider/Germany.php
@@ -21,7 +21,6 @@ use Michalmanko\Holiday\Holiday;
  */
 class Germany extends AbstractProvider
 {
-
     /**
      * {@inheritdoc}
      */
@@ -58,6 +57,13 @@ class Germany extends AbstractProvider
         $easterMonday->modify('+1 day');
         $data->append($easterMonday);
 
+        // Labour Day
+        $data->append($this->createHoliday(
+            'Erster Mai',
+            $year . '-05-01',
+            Holiday::TYPE_HOLIDAY
+        ));
+
         // Feast of the Ascension
         $feastOfTheAscension = $this->createHoliday(
             'Christi Himmelfahrt',
@@ -86,13 +92,6 @@ class Germany extends AbstractProvider
         $data->append($this->createHoliday(
             'Tag der Deutschen Einheit',
             $year . '-10-03',
-            Holiday::TYPE_HOLIDAY
-        ));
-
-        // Labour Day
-        $data->append($this->createHoliday(
-            'Erster Mai',
-            $year . '-05-01',
             Holiday::TYPE_HOLIDAY
         ));
 
@@ -125,6 +124,7 @@ class Germany extends AbstractProvider
     }
 
     /**
+     * Returns Holiday instance for Pentecost Sunday of the given year
      * @param $year
      * @return Holiday
      */
@@ -137,15 +137,17 @@ class Germany extends AbstractProvider
     }
 
     /**
+     * Returns Holiday instance for Epiphany day of the given year
      * @param $year
      * @return Holiday
      */
-    public function getHolidayEpiphandy($year)
+    public function getHolidayEpiphany($year)
     {
         return $this->createHoliday('Heilige Drei Könige', $year . '-01-06', Holiday::TYPE_HOLIDAY);
     }
 
     /**
+     * Returns Holiday instance for Easter Sunday of the given year
      * @param $year
      * @return Holiday
      */
@@ -154,6 +156,11 @@ class Germany extends AbstractProvider
         return $this->createHoliday('Ostersonntag', $this->getEaster($year), Holiday::TYPE_HOLIDAY);
     }
 
+    /**
+     * Returns Holiday instance for Corpus Christi day of the given year
+     * @param $year
+     * @return Holiday
+     */
     public function getHolidayCorpusChristi($year)
     {
         $corpusChristi = $this->createHoliday('Fronleichnam', $this->getEaster($year), Holiday::TYPE_HOLIDAY);
@@ -162,6 +169,7 @@ class Germany extends AbstractProvider
     }
 
     /**
+     * Returns Holiday instance for Assumption Of The Blessed Virgin Mary day of the given year
      * @param $year
      * @return Holiday
      */
@@ -181,6 +189,7 @@ class Germany extends AbstractProvider
     }
 
     /**
+     * Returns Holiday instance for All Saints Day of the given year
      * @param $year
      * @return Holiday
      */
@@ -190,6 +199,7 @@ class Germany extends AbstractProvider
     }
 
     /**
+     * Returns Holiday instance for "Buß Und Bett Tag" of the given year
      * @param $year
      * @return Holiday
      */

--- a/src/Michalmanko/Holiday/Provider/GermanyBB.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBB.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyBB extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyBB.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBB.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Brandenburg (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBB extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayEasterSunday($year));
+        $data->append($this->getHolidayPentecostSunday($year));
+        if ($year != 2017)
+            $data->append($this->getHolidayReformationDay($year));
+        
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyBE.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBE.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyBE extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyBE.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBE.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Berlin (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBE extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+        
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyBW.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBW.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Baden-Württemberg (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBW extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayEpiphandy($year));
+        $data->append($this->getHolidayCorpusChristi($year));
+        $data->append($this->getHolidayAllSaintsDay($year));
+        
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyBW.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBW.php
@@ -20,12 +20,15 @@ use ArrayObject;
  */
 class GermanyBW extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */
         $data = new ArrayObject(parent::prepareHolidays($year));
 
-        $data->append($this->getHolidayEpiphandy($year));
+        $data->append($this->getHolidayEpiphany($year));
         $data->append($this->getHolidayCorpusChristi($year));
         $data->append($this->getHolidayAllSaintsDay($year));
         

--- a/src/Michalmanko/Holiday/Provider/GermanyBY.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBY.php
@@ -20,12 +20,15 @@ use ArrayObject;
  */
 class GermanyBY extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */
         $data = new ArrayObject(parent::prepareHolidays($year));
 
-        $data->append($this->getHolidayEpiphandy($year));
+        $data->append($this->getHolidayEpiphany($year));
         $data->append($this->getHolidayCorpusChristi($year));
         $data->append($this->getHolidayAllSaintsDay($year));
         

--- a/src/Michalmanko/Holiday/Provider/GermanyBY.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyBY.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Bavaria (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBY extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayEpiphandy($year));
+        $data->append($this->getHolidayCorpusChristi($year));
+        $data->append($this->getHolidayAllSaintsDay($year));
+        
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyHB.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHB.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyHB extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyHB.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHB.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Bremen (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHB extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyHE.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHE.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Hesse (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHE extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayEasterSunday($year));
+        $data->append($this->getHolidayPentecostSunday($year));
+        $data->append($this->getHolidayCorpusChristi($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyHE.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHE.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyHE extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyHH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHH.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyHH extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyHH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyHH.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Hamburg (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHH extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyMV.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyMV.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyMV extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyMV.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyMV.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Mecklenburg-Vorpommern (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyMV extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        if ($year != 2017)
+            $data->append($this->getHolidayReformationDay($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyNI.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyNI.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Lower Saxony (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyNI extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyNI.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyNI.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyNI extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyNW.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyNW.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * North Rhine-Westphalia (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyNW extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayCorpusChristi($year));
+        $data->append($this->getHolidayAllSaintsDay($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyNW.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyNW.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyNW extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyRP.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyRP.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Rhineland-Palatinate (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyRP extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayCorpusChristi($year));
+        $data->append($this->getHolidayAllSaintsDay($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyRP.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyRP.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyRP extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanySH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySH.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanySH extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanySH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySH.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Schleswig-Holstein (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySH extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanySL.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySL.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Saarland (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySL extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayCorpusChristi($year));
+        $data->append($this->getHolidayAllSaintsDay($year));
+        $data->append($this->getHolidayAssumptionOfTheBlessedVirginMary($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanySL.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySL.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanySL extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanySN.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySN.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanySN extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanySN.php
+++ b/src/Michalmanko/Holiday/Provider/GermanySN.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Saxony (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySN extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        if ($year != 2017)
+            $data->append($this->getHolidayReformationDay($year));
+        $data->append($this->getHolidayBuszUndBettTag($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyST.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyST.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Saxony-Anhalt (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyST extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        $data->append($this->getHolidayEpiphandy($year));
+        if ($year != 2017)
+            $data->append($this->getHolidayReformationDay($year));
+
+        return $data;
+    }
+}

--- a/src/Michalmanko/Holiday/Provider/GermanyST.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyST.php
@@ -20,12 +20,15 @@ use ArrayObject;
  */
 class GermanyST extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */
         $data = new ArrayObject(parent::prepareHolidays($year));
 
-        $data->append($this->getHolidayEpiphandy($year));
+        $data->append($this->getHolidayEpiphany($year));
         if ($year != 2017)
             $data->append($this->getHolidayReformationDay($year));
 

--- a/src/Michalmanko/Holiday/Provider/GermanyTH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyTH.php
@@ -20,6 +20,9 @@ use ArrayObject;
  */
 class GermanyTH extends Germany
 {
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareHolidays($year)
     {
         /** @var ArrayObject $data */

--- a/src/Michalmanko/Holiday/Provider/GermanyTH.php
+++ b/src/Michalmanko/Holiday/Provider/GermanyTH.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Provider;
+
+use ArrayObject;
+
+/**
+ * Thuringia (state of Germany) Holidays Provider.
+ *
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyTH extends Germany
+{
+    protected function prepareHolidays($year)
+    {
+        /** @var ArrayObject $data */
+        $data = new ArrayObject(parent::prepareHolidays($year));
+
+        if ($year != 2017)
+            $data->append($this->getHolidayReformationDay($year));
+        
+        return $data;
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/HolidayFactoryTest.php
+++ b/tests/Michalmanko/Holiday/Test/HolidayFactoryTest.php
@@ -39,15 +39,97 @@ class HolidayFactoryTest extends PHPUnit_Framework_TestCase
             '\\Michalmanko\\Holiday\\Test\\Provider\\Provider'
         );
 
-        $provider2 = HolidayFactory::createProvider('Country');
+        $providerCountry = HolidayFactory::createProvider('Country');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerCountry);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Test\\Provider\\Provider', $providerCountry);
 
-        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $provider2);
-        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Test\\Provider\\Provider', $provider2);
+        $providerPoland = HolidayFactory::createProvider('Poland');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerPoland);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Poland', $providerPoland);
 
-        $provider3 = HolidayFactory::createProvider('Poland');
+        $providerGermany = HolidayFactory::createProvider('Germany');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermany);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermany);
 
-        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $provider3);
-        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Poland', $provider3);
+        $providerGermanyBB = HolidayFactory::createProvider('GermanyBB');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyBB);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyBB);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyBB', $providerGermanyBB);
+
+        $providerGermanyBE = HolidayFactory::createProvider('GermanyBE');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyBE);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyBE);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyBE', $providerGermanyBE);
+
+        $providerGermanyBW = HolidayFactory::createProvider('GermanyBW');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyBW);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyBW);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyBW', $providerGermanyBW);
+
+        $providerGermanyBY = HolidayFactory::createProvider('GermanyBY');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyBY);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyBY);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyBY', $providerGermanyBY);
+
+        $providerGermanyHB = HolidayFactory::createProvider('GermanyHB');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyHB);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyHB);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyHB', $providerGermanyHB);
+
+        $providerGermanyHE = HolidayFactory::createProvider('GermanyHE');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyHE);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyHE);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyHE', $providerGermanyHE);
+
+        $providerGermanyHH = HolidayFactory::createProvider('GermanyHH');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyHH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyHH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyHH', $providerGermanyHH);
+
+        $providerGermanyMV = HolidayFactory::createProvider('GermanyMV');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyMV);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyMV);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyMV', $providerGermanyMV);
+
+        $providerGermanyNI = HolidayFactory::createProvider('GermanyNI');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyNI);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyNI);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyNI', $providerGermanyNI);
+
+        $providerGermanyNW = HolidayFactory::createProvider('GermanyNW');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyNW);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyNW);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyNW', $providerGermanyNW);
+
+        $providerGermanyRP = HolidayFactory::createProvider('GermanyRP');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyRP);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyRP);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyRP', $providerGermanyRP);
+
+        $providerGermanySH = HolidayFactory::createProvider('GermanySH');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanySH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanySH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanySH', $providerGermanySH);
+
+        $providerGermanySL = HolidayFactory::createProvider('GermanySL');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanySL);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanySL);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanySL', $providerGermanySL);
+
+        $providerGermanySN = HolidayFactory::createProvider('GermanySN');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanySN);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanySN);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanySN', $providerGermanySN);
+
+        $providerGermanyST = HolidayFactory::createProvider('GermanyST');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyST);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyST);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyST', $providerGermanyST);
+
+        $providerGermanyTH = HolidayFactory::createProvider('GermanyTH');
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\AbstractProvider', $providerGermanyTH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\Germany', $providerGermanyTH);
+        $this->assertInstanceOf('\\Michalmanko\\Holiday\\Provider\\GermanyTH', $providerGermanyTH);
     }
 
     public function testProviderFactoryNotFound()

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyBBTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyBBTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBBTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_BB';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyBB';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyBB';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getEasterSundayTestData(),
+            $this->getPentecostSundayTestData(),
+            $this->getReformationTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyBETest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyBETest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBETest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_BE';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyBE';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyBE';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            //
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyBWTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyBWTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBWTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_BW';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyBW';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyBW';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getEpiphanyTestData(),
+            $this->getCorpusChristiTestData(),
+            $this->getAllSaintsDayTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyBYTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyBYTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyBYTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_BY';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyBY';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyBY';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getEpiphanyTestData(),
+            $this->getCorpusChristiTestData(),
+            $this->getAllSaintsDayTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyHBTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyHBTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHBTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_HB';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyHB';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyHB';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            //
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyHETest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyHETest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHETest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_HE';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyHE';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyHE';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getEasterSundayTestData(),
+            $this->getPentecostSundayTestData(),
+            $this->getCorpusChristiTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyHHTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyHHTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyHHTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_HH';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyHH';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyHH';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            //
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyMVTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyMVTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyMVTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_MV';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyMV';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyMV';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getReformationTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyNITest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyNITest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyNITest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_NI';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyNI';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyNI';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            //
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyNWTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyNWTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyNWTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_NW';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyNW';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyNW';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getCorpusChristiTestData(),
+            $this->getAllSaintsDayTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyRPTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyRPTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyRPTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_RP';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyRP';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyRP';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getCorpusChristiTestData(),
+            $this->getAllSaintsDayTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanySHTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanySHTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySHTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_SH';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanySH';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanySH';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            //
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanySLTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanySLTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySLTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_SL';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanySL';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanySL';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getCorpusChristiTestData(),
+            $this->getAllSaintsDayTestData(),
+            $this->getAssumptionOfTheBlessedVirginMaryTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanySNTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanySNTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySNTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_SN';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanySN';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanySN';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getReformationTestData(),
+            $this->getBuszUndBettTagTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanySTTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanySTTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanySTTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_ST';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyST';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyST';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getEpiphanyTestData(),
+            $this->getReformationTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyTHTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyTHTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyTHTest extends GermanyTest
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER_TH';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'GermanyTH';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\GermanyTH';
+    }
+
+    public function dataProvider()
+    {
+        $parentData = parent::dataProvider();
+
+        $providerData = array(
+            $this->getReformationTestData(),
+        );
+
+        return array_merge($parentData, $providerData);
+    }
+}

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
@@ -36,16 +36,16 @@ class GermanyTest extends AbstractTestProvider
     public function dataProvider()
     {
         return array(
-            ['Neujahr', Holiday::TYPE_HOLIDAY, array('2015-01-01', '2020-01-01')],
-            ['Karfreitag', Holiday::TYPE_HOLIDAY, array('2015-04-03', '2020-04-10')],
-            ['Ostermontag', Holiday::TYPE_HOLIDAY, array('2015-04-06', '2020-04-13')],
-            ['Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21', '2025-05-29')],
-            ['Erster Mai', Holiday::TYPE_HOLIDAY, array('2015-05-01', '2020-05-01', '2025-05-01')],
-            ['Pfingstmontag', Holiday::TYPE_HOLIDAY, array('2015-05-25', '2020-06-01', '2025-06-09')],
-            ['Tag der Deutschen Einheit', Holiday::TYPE_HOLIDAY, array('2015-10-03', '2020-10-03', '2025-10-03')],
-            ['Reformationstag', Holiday::TYPE_HOLIDAY, array('2017-10-31')],
-            ['1. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-25', '2020-12-25')],
-            ['2. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-26', '2020-12-26')],
+            array('Neujahr', Holiday::TYPE_HOLIDAY, array('2015-01-01', '2020-01-01')),
+            array('Karfreitag', Holiday::TYPE_HOLIDAY, array('2015-04-03', '2020-04-10')),
+            array('Ostermontag', Holiday::TYPE_HOLIDAY, array('2015-04-06', '2020-04-13')),
+            array('Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21', '2025-05-29')),
+            array('Erster Mai', Holiday::TYPE_HOLIDAY, array('2015-05-01', '2020-05-01', '2025-05-01')),
+            array('Pfingstmontag', Holiday::TYPE_HOLIDAY, array('2015-05-25', '2020-06-01', '2025-06-09')),
+            array('Tag der Deutschen Einheit', Holiday::TYPE_HOLIDAY, array('2015-10-03', '2020-10-03', '2025-10-03')),
+            array('Reformationstag', Holiday::TYPE_HOLIDAY, array('2017-10-31')),
+            array('1. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-25', '2020-12-25')),
+            array('2. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-26', '2020-12-26')),
         );
     }
 

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
@@ -51,41 +51,41 @@ class GermanyTest extends AbstractTestProvider
 
     public function getEasterSundayTestData()
     {
-        return ['Ostersonntag', Holiday::TYPE_HOLIDAY, array('2015-04-05', '2020-04-12')];
+        return array('Ostersonntag', Holiday::TYPE_HOLIDAY, array('2015-04-05', '2020-04-12'));
     }
 
     public function getPentecostSundayTestData()
     {
-        return ['Pfingstsonntag', Holiday::TYPE_HOLIDAY, array('2015-05-24', '2020-05-31')];
+        return array('Pfingstsonntag', Holiday::TYPE_HOLIDAY, array('2015-05-24', '2020-05-31'));
     }
 
     public function getReformationTestData()
     {
-        return ['Reformationstag', Holiday::TYPE_HOLIDAY, array('2015-10-31', '2020-10-31')];
+        return array('Reformationstag', Holiday::TYPE_HOLIDAY, array('2015-10-31', '2020-10-31'));
     }
 
     public function getEpiphanyTestData()
     {
-        return ['Heilige Drei Könige', Holiday::TYPE_HOLIDAY, array('2015-01-06', '2020-01-06')];
+        return array('Heilige Drei Könige', Holiday::TYPE_HOLIDAY, array('2015-01-06', '2020-01-06'));
     }
 
     public function getCorpusChristiTestData()
     {
-        return ['Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21')];
+        return array('Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21'));
     }
 
     public function getAllSaintsDayTestData()
     {
-        return ['Allerheiligen', Holiday::TYPE_HOLIDAY, array('2015-11-01', '2020-11-01')];
+        return array('Allerheiligen', Holiday::TYPE_HOLIDAY, array('2015-11-01', '2020-11-01'));
     }
 
     public function getAssumptionOfTheBlessedVirginMaryTestData()
     {
-        return ['Mariä Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-08-15', '2020-08-15')];
+        return array('Mariä Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-08-15', '2020-08-15'));
     }
 
     public function getBuszUndBettTagTestData()
     {
-        return ['Buß- und Bettag', Holiday::TYPE_HOLIDAY, array('2015-11-18', '2020-11-18')];
+        return array('Buß- und Bettag', Holiday::TYPE_HOLIDAY, array('2015-11-18', '2020-11-18'));
     }
 }

--- a/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
+++ b/tests/Michalmanko/Holiday/Test/Provider/GermanyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Holiday Library.
+ *
+ * (c) Michał Mańko <github@michalmanko.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Michalmanko\Holiday\Test\Provider;
+
+use Michalmanko\Holiday\Holiday;
+
+/**
+ * @author ottowayne <mr.ottowayne@gmail.com>
+ */
+class GermanyTest extends AbstractTestProvider
+{
+    public function getProviderCountryCode()
+    {
+        return 'GER';
+    }
+
+    public function getProviderCountryName()
+    {
+        return 'Germany';
+    }
+
+    public function getProviderInstanceOf()
+    {
+        return '\\Michalmanko\\Holiday\\Provider\\Germany';
+    }
+
+    public function dataProvider()
+    {
+        return array(
+            ['Neujahr', Holiday::TYPE_HOLIDAY, array('2015-01-01', '2020-01-01')],
+            ['Karfreitag', Holiday::TYPE_HOLIDAY, array('2015-04-03', '2020-04-10')],
+            ['Ostermontag', Holiday::TYPE_HOLIDAY, array('2015-04-06', '2020-04-13')],
+            ['Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21', '2025-05-29')],
+            ['Erster Mai', Holiday::TYPE_HOLIDAY, array('2015-05-01', '2020-05-01', '2025-05-01')],
+            ['Pfingstmontag', Holiday::TYPE_HOLIDAY, array('2015-05-25', '2020-06-01', '2025-06-09')],
+            ['Tag der Deutschen Einheit', Holiday::TYPE_HOLIDAY, array('2015-10-03', '2020-10-03', '2025-10-03')],
+            ['Reformationstag', Holiday::TYPE_HOLIDAY, array('2017-10-31')],
+            ['1. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-25', '2020-12-25')],
+            ['2. Weihnachtstag', Holiday::TYPE_HOLIDAY, array('2015-12-26', '2020-12-26')],
+        );
+    }
+
+    public function getEasterSundayTestData()
+    {
+        return ['Ostersonntag', Holiday::TYPE_HOLIDAY, array('2015-04-05', '2020-04-12')];
+    }
+
+    public function getPentecostSundayTestData()
+    {
+        return ['Pfingstsonntag', Holiday::TYPE_HOLIDAY, array('2015-05-24', '2020-05-31')];
+    }
+
+    public function getReformationTestData()
+    {
+        return ['Reformationstag', Holiday::TYPE_HOLIDAY, array('2015-10-31', '2020-10-31')];
+    }
+
+    public function getEpiphanyTestData()
+    {
+        return ['Heilige Drei Könige', Holiday::TYPE_HOLIDAY, array('2015-01-06', '2020-01-06')];
+    }
+
+    public function getCorpusChristiTestData()
+    {
+        return ['Christi Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-05-14', '2020-05-21')];
+    }
+
+    public function getAllSaintsDayTestData()
+    {
+        return ['Allerheiligen', Holiday::TYPE_HOLIDAY, array('2015-11-01', '2020-11-01')];
+    }
+
+    public function getAssumptionOfTheBlessedVirginMaryTestData()
+    {
+        return ['Mariä Himmelfahrt', Holiday::TYPE_HOLIDAY, array('2015-08-15', '2020-08-15')];
+    }
+
+    public function getBuszUndBettTagTestData()
+    {
+        return ['Buß- und Bettag', Holiday::TYPE_HOLIDAY, array('2015-11-18', '2020-11-18')];
+    }
+}


### PR DESCRIPTION
Since the states in Germany differ in their holidays I had to split them up in different providers but inherited from the original class for nationwide holidays.
